### PR TITLE
Add ref fields Id and ScheduledAt

### DIFF
--- a/ref.go
+++ b/ref.go
@@ -1,6 +1,7 @@
 package goprismic
 
 type Ref struct {
+	Id          string `json:"id"`
 	Ref         string `json:"ref"`
 	Label       string `json:"label"`
 	IsMasterRef bool   `json:"isMasterRef"`

--- a/ref.go
+++ b/ref.go
@@ -1,8 +1,21 @@
 package goprismic
 
+import "time"
+
 type Ref struct {
 	Id          string `json:"id"`
 	Ref         string `json:"ref"`
 	Label       string `json:"label"`
 	IsMasterRef bool   `json:"isMasterRef"`
+	ScheduledAt int64  `json:"scheduledAt"`
+}
+
+func (r *Ref) ScheduledTime() *time.Time {
+	if r.ScheduledAt == 0 {
+		return nil
+	}
+	sec := r.ScheduledAt / 1000
+	nsec := (r.ScheduledAt % 1000) * 1000
+	date := time.Unix(sec, nsec)
+	return &date
 }


### PR DESCRIPTION
These fields are returned by the API but were not stored into the `Ref` objects.

I added a helper to return the `scheduledAt` field as a `time.Time` instead of a timestamp.
