### PR TITLE
Fix panic when image's alt and copyright field is null

### DIFF
--- a/fragment/image/view.go
+++ b/fragment/image/view.go
@@ -25,10 +25,20 @@ func (i *View) Decode(enc interface{}) error {
 		i.Url = v.(string)
 	}
 	if v, found := dec["alt"]; found {
-		i.Alt = v.(string)
+		switch v.(type) {
+		case string:
+			i.Alt = v.(string)
+		default:
+			i.Alt = ""
+		}
 	}
 	if v, found := dec["copyright"]; found {
-		i.Copyright = v.(string)
+		switch v.(type) {
+		case string:
+			i.Copyright = v.(string)
+		default:
+			i.Copyright = ""
+		}
 	}
 	if d, found := dec["dimensions"]; found {
 		dim, ok := d.(map[string]interface{})


### PR DESCRIPTION
Current parsing system cause panic error when json includes null whre corresponding key exists.

The example which causes panic is on my repository's issue:

[https://github.com/Qs-F/goprismic/issues/1](https://github.com/Qs-F/goprismic/issues/1)